### PR TITLE
Fix jax.experimental.pjit issues

### DIFF
--- a/colabs/quick_start.ipynb
+++ b/colabs/quick_start.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": 42,
       "metadata": {
         "id": "qTrunCDp6HAD"
       },
@@ -31,7 +31,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 43,
       "metadata": {
         "id": "EdzHCJuop4ZB"
       },
@@ -50,64 +50,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 44,
       "metadata": {
         "id": "s2cBBZEk1_DG"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Collecting git+https://github.com/google-research/jaxpruner\n",
-            "  Cloning https://github.com/google-research/jaxpruner to /private/var/folders/sq/g9fv1ssn3yqg_27cnkj1_c100000gr/T/pip-req-build-zhu9jesb\n",
-            "  Running command git clone --filter=blob:none --quiet https://github.com/google-research/jaxpruner /private/var/folders/sq/g9fv1ssn3yqg_27cnkj1_c100000gr/T/pip-req-build-zhu9jesb\n",
-            "  Resolved https://github.com/google-research/jaxpruner to commit f133ee50f31a03d0152b8b272edb534065152f5d\n",
-            "  Installing build dependencies ... \u001b[?25ldone\n",
-            "\u001b[?25h  Getting requirements to build wheel ... \u001b[?25ldone\n",
-            "\u001b[?25h  Preparing metadata (pyproject.toml) ... \u001b[?25ldone\n",
-            "\u001b[?25hRequirement already satisfied: chex in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.1.88)\n",
-            "Requirement already satisfied: flax in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.10.2)\n",
-            "Requirement already satisfied: jax in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.4.38)\n",
-            "Requirement already satisfied: jaxlib in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.4.38)\n",
-            "Requirement already satisfied: optax in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.2.4)\n",
-            "Requirement already satisfied: numpy in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (2.2.1)\n",
-            "Requirement already satisfied: ml-collections in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (1.0.0)\n",
-            "Requirement already satisfied: absl-py>=0.9.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (2.1.0)\n",
-            "Requirement already satisfied: typing_extensions>=4.2.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (4.12.2)\n",
-            "Requirement already satisfied: setuptools in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (75.7.0)\n",
-            "Requirement already satisfied: toolz>=0.9.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (1.0.0)\n",
-            "Requirement already satisfied: ml_dtypes>=0.4.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jax->jaxpruner==0.1) (0.5.0)\n",
-            "Requirement already satisfied: opt_einsum in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jax->jaxpruner==0.1) (3.4.0)\n",
-            "Requirement already satisfied: scipy>=1.10 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jax->jaxpruner==0.1) (1.15.0)\n",
-            "Requirement already satisfied: msgpack in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (1.1.0)\n",
-            "Requirement already satisfied: orbax-checkpoint in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (0.11.0)\n",
-            "Requirement already satisfied: tensorstore in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (0.1.71)\n",
-            "Requirement already satisfied: rich>=11.1 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (13.9.4)\n",
-            "Requirement already satisfied: PyYAML>=5.4.1 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (6.0.2)\n",
-            "Requirement already satisfied: six in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from ml-collections->jaxpruner==0.1) (1.17.0)\n",
-            "Requirement already satisfied: etils[epy] in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from optax->jaxpruner==0.1) (1.11.0)\n",
-            "Requirement already satisfied: markdown-it-py>=2.2.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from rich>=11.1->flax->jaxpruner==0.1) (3.0.0)\n",
-            "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from rich>=11.1->flax->jaxpruner==0.1) (2.19.1)\n",
-            "Requirement already satisfied: nest_asyncio in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (1.6.0)\n",
-            "Requirement already satisfied: protobuf in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (5.29.2)\n",
-            "Requirement already satisfied: humanize in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (4.11.0)\n",
-            "Requirement already satisfied: simplejson>=3.16.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (3.19.3)\n",
-            "Requirement already satisfied: mdurl~=0.1 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=11.1->flax->jaxpruner==0.1) (0.1.2)\n",
-            "Requirement already satisfied: fsspec in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from etils[epy]->optax->jaxpruner==0.1) (2024.12.0)\n",
-            "Requirement already satisfied: importlib_resources in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from etils[epy]->optax->jaxpruner==0.1) (6.5.2)\n",
-            "Requirement already satisfied: zipp in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from etils[epy]->optax->jaxpruner==0.1) (3.21.0)\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages/ml_collections/config_dict/config_dict.py:163: SyntaxWarning: invalid escape sequence '\\['\n",
-            "  index_match = re.match(\"(.*)\\[([0-9]+)\\]\", key)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# !pip3 install git+https://github.com/google-research/jaxpruner\n",
         "import jaxpruner\n",
@@ -128,23 +75,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {
         "id": "D-3sagbVuOCW"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[[0.28248537 0.0030005  0.5755601  0.80048716 0.24104941]\n",
-            " [0.4520849  0.30063164 0.11872995 0.9262264  0.02943528]\n",
-            " [0.77339077 0.9098681  0.30932128 0.9311595  0.7131189 ]\n",
-            " [0.76767194 0.60364604 0.54187894 0.54719424 0.68919384]\n",
-            " [0.6382148  0.9619373  0.9574717  0.21418309 0.21543407]]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "matrix_size = 5\n",
         "learning_rate = 0.01\n",
@@ -154,29 +89,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": null,
       "metadata": {
         "id": "G51lY-u3xxa6"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[[0.        0.        0.        0.        0.       ]\n",
-            " [0.        0.        0.        0.9262264 0.       ]\n",
-            " [0.        0.9098681 0.        0.9311595 0.       ]\n",
-            " [0.        0.        0.        0.        0.       ]\n",
-            " [0.        0.9619373 0.9574717 0.        0.       ]]\n",
-            "uint8\n",
-            "[[0 0 0 0 0]\n",
-            " [0 0 0 1 0]\n",
-            " [0 1 0 1 0]\n",
-            " [0 0 0 0 0]\n",
-            " [0 1 1 0 0]]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "sparsity_distribution = functools.partial(\n",
         "    jaxpruner.sparsity_distributions.uniform, sparsity=0.8)\n",
@@ -199,29 +116,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "JCwUUA2SCkTy"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[[0.         0.         0.         0.80048716 0.        ]\n",
-            " [0.         0.         0.         0.9262264  0.        ]\n",
-            " [0.         0.         0.         0.9311595  0.        ]\n",
-            " [0.76767194 0.         0.         0.         0.        ]\n",
-            " [0.         0.9619373  0.         0.         0.        ]]\n",
-            "uint8\n",
-            "[[0 0 0 1 0]\n",
-            " [0 0 0 1 0]\n",
-            " [0 0 0 1 0]\n",
-            " [1 0 0 0 0]\n",
-            " [0 1 0 0 0]]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "pruner = jaxpruner.MagnitudePruning(sparsity_distribution_fn=sparsity_distribution,\n",
         "                                    sparsity_type=jaxpruner.sparsity_types.NByM(1, 5))\n",
@@ -243,28 +142,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "id": "w7swztVv1pwN"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "{'inv': Array([[0.        , 0.9969995 , 0.        , 0.        , 0.        ],\n",
-            "       [0.        , 0.        , 0.        , 0.        , 0.9705647 ],\n",
-            "       [0.        , 0.        , 0.6906787 , 0.        , 0.        ],\n",
-            "       [0.        , 0.        , 0.45812106, 0.        , 0.        ],\n",
-            "       [0.        , 0.        , 0.        , 0.7858169 , 0.        ]],      dtype=float32),\n",
-            " 'pos': Array([[0.        , 0.        , 0.        , 0.80048716, 0.        ],\n",
-            "       [0.        , 0.        , 0.        , 0.9262264 , 0.        ],\n",
-            "       [0.        , 0.        , 0.        , 0.9311595 , 0.        ],\n",
-            "       [0.76767194, 0.        , 0.        , 0.        , 0.        ],\n",
-            "       [0.        , 0.9619373 , 0.        , 0.        , 0.        ]],      dtype=float32)}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# params = [matrix, 1 - matrix]\n",
         "params = {'pos': matrix, 'inv': 1 - matrix}\n",
@@ -283,23 +165,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {
         "id": "XN2954cfFChC"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "{'_nparams': Array(50., dtype=float32),\n",
-            " '_nparams_nnz': Array(20., dtype=float32),\n",
-            " '_total_sparsity': Array(0.6, dtype=float32),\n",
-            " 'inv': Array(0.8, dtype=float32),\n",
-            " 'pos': Array(0.39999998, dtype=float32)}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "def custom_distribution(params, sparsity=0.8):\n",
         "  return {key: 0.4 if 'pos' in key else sparsity for key in params}\n",
@@ -320,24 +190,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "id": "nOaXL58kpZfv"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "{'inv': Array([[0, 1, 0, 0, 0],\n",
-            "       [0, 0, 1, 0, 1],\n",
-            "       [0, 0, 0, 0, 0],\n",
-            "       [0, 0, 0, 0, 0],\n",
-            "       [0, 0, 0, 1, 1]], dtype=uint8),\n",
-            " 'pos': None}\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "def custom_distribution2(params, sparsity=0.8):\n",
         "  return {key: None if 'pos' in key else sparsity for key in params}\n",
@@ -358,29 +215,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "id": "VZUIsC1NH5JV"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "no_prune <class 'jaxpruner.base_updater.NoPruning'>\n",
-            "magnitude <class 'jaxpruner.algorithms.pruners.MagnitudePruning'>\n",
-            "random <class 'jaxpruner.algorithms.pruners.RandomPruning'>\n",
-            "saliency <class 'jaxpruner.algorithms.pruners.SaliencyPruning'>\n",
-            "magnitude_ste <class 'jaxpruner.algorithms.ste.SteMagnitudePruning'>\n",
-            "random_ste <class 'jaxpruner.algorithms.ste.SteRandomPruning'>\n",
-            "global_magnitude <class 'jaxpruner.algorithms.global_pruners.GlobalMagnitudePruning'>\n",
-            "global_saliency <class 'jaxpruner.algorithms.global_pruners.GlobalSaliencyPruning'>\n",
-            "static_sparse <class 'jaxpruner.algorithms.sparse_trainers.StaticRandomSparse'>\n",
-            "rigl <class 'jaxpruner.algorithms.sparse_trainers.RigL'>\n",
-            "set <class 'jaxpruner.algorithms.sparse_trainers.SET'>\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "for k in jaxpruner.ALGORITHM_REGISTRY:\n",
         "  print(k, jaxpruner.ALGORITHM_REGISTRY[k])"
@@ -397,23 +236,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {
         "id": "n_1waBgM2Epe"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[[0.         0.         0.5755601  0.         0.        ]\n",
-            " [0.4520849  0.         0.         0.         0.        ]\n",
-            " [0.         0.         0.         0.         0.        ]\n",
-            " [0.         0.60364604 0.54187894 0.54719424 0.        ]\n",
-            " [0.         0.         0.         0.         0.        ]]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Gradient based pruning\n",
         "pruner = jaxpruner.SaliencyPruning(sparsity_distribution_fn=sparsity_distribution)\n",
@@ -437,7 +264,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 53,
       "metadata": {
         "id": "ZPVLns38l-sS"
       },
@@ -482,37 +309,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "id": "imi-PawzUS_6"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Step: 0, loss: 50.740779876708984\n",
-            "Step: 4, loss: 1.0821640491485596\n",
-            "Step: 8, loss: 0.5029404163360596\n",
-            "Step: 12, loss: 0.09175926446914673\n",
-            "Step: 16, loss: 0.0036935126408934593\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Array([[-0.5452558 , -0.68374544,  0.39526057,  0.27897137, -0.01504929],\n",
-              "       [ 0.18433541, -0.26916775, -0.45707935,  0.31126106, -0.76552254],\n",
-              "       [-0.6820641 ,  0.08165327, -0.69178694, -0.14950337,  0.15661548],\n",
-              "       [ 0.33259526, -0.6524972 , -0.23232982, -0.6030979 ,  0.20593995],\n",
-              "       [-0.2942041 ,  0.16224197,  0.3196011 , -0.66244096, -0.5882758 ]],      dtype=float32)"
-            ]
-          },
-          "execution_count": 13,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "params = jax.random.uniform(jax.random.PRNGKey(8),\n",
         "                            shape=(matrix_size, matrix_size))\n",
@@ -530,7 +331,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 55,
       "metadata": {
         "id": "plZ5bqDhT4cR"
       },
@@ -568,42 +369,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {
         "id": "TqaMojfRNGHd"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Step: 0, loss: 50.740779876708984\n",
-            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 4, loss: 1.0821640491485596\n",
-            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 8, loss: 0.5029404163360596\n",
-            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 12, loss: 1.8950453996658325\n",
-            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 16, loss: 1.3515889644622803\n",
-            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Array([[-0.        , -0.99310285,  0.        ,  0.        , -0.        ],\n",
-              "       [ 0.        , -0.        , -0.        ,  0.        , -0.9267426 ],\n",
-              "       [-0.        ,  0.        , -0.9929704 , -0.        ,  0.        ],\n",
-              "       [ 0.        , -0.        , -0.        , -0.        ,  0.        ],\n",
-              "       [-0.        ,  0.        ,  0.        , -0.9202637 , -0.2308394 ]],      dtype=float32)"
-            ]
-          },
-          "execution_count": 15,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "pruner = jaxpruner.MagnitudePruning(\n",
         "    sparsity_distribution_fn=sparsity_distribution,\n",
@@ -625,42 +395,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": null,
       "metadata": {
         "id": "Tg9MAEYsO8YU"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Step: 0, loss: 50.740779876708984\n",
-            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 4, loss: 1.0821640491485596\n",
-            "{'_total_sparsity': Array(0.48000002, dtype=float32), '_nparams_nnz': Array(13., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 8, loss: 1.2138574123382568\n",
-            "{'_total_sparsity': Array(0.76, dtype=float32), '_nparams_nnz': Array(6., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 12, loss: 1.3473515510559082\n",
-            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 16, loss: 1.0177024602890015\n",
-            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Array([[-0.        , -0.9976892 ,  0.        ,  0.        , -0.        ],\n",
-              "       [ 0.        , -0.        , -0.        ,  0.        , -0.9915333 ],\n",
-              "       [-0.        , -0.        , -0.99801445, -0.        ,  0.        ],\n",
-              "       [ 0.        , -0.        , -0.        , -0.67936283,  0.        ],\n",
-              "       [-0.        ,  0.        ,  0.        , -0.7284256 , -0.        ]],      dtype=float32)"
-            ]
-          },
-          "execution_count": 16,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "pruner = jaxpruner.MagnitudePruning(\n",
         "    sparsity_distribution_fn=sparsity_distribution,\n",
@@ -692,7 +431,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 58,
       "metadata": {
         "id": "TKY_GSumHYRI"
       },
@@ -709,42 +448,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "metadata": {
         "id": "Uqqg0sYIHWNm"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Step: 0, loss: 50.740779876708984\n",
-            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 4, loss: 1.0821640491485596\n",
-            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 8, loss: 0.7265740036964417\n",
-            "{'_total_sparsity': Array(0.48000002, dtype=float32), '_nparams_nnz': Array(13., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 12, loss: 1.3116353750228882\n",
-            "{'_total_sparsity': Array(0.6, dtype=float32), '_nparams_nnz': Array(10., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
-            "Step: 16, loss: 1.129997730255127\n",
-            "{'_total_sparsity': Array(0.6, dtype=float32), '_nparams_nnz': Array(10., dtype=float32), '_nparams': Array(25., dtype=float32)}\n"
-          ]
-        },
-        {
-          "data": {
-            "text/plain": [
-              "Array([[-0.5102305 , -0.6804417 ,  0.        ,  0.        , -0.        ],\n",
-              "       [ 0.        , -0.        , -0.        ,  0.5152243 , -0.8074678 ],\n",
-              "       [-0.44380936,  0.        , -0.8579842 , -0.        ,  0.        ],\n",
-              "       [ 0.        , -0.55724764, -0.        , -0.38684854,  0.        ],\n",
-              "       [-0.        ,  0.        ,  0.        , -0.72127473, -0.58689326]],      dtype=float32)"
-            ]
-          },
-          "execution_count": 18,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Create a dense layer and sparsify.\n",
         "pruner = jaxpruner.create_updater_from_config(sparsity_config)\n",
@@ -781,54 +489,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
         "id": "T8EchfPLEei-"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Step: 0, loss: 343.5727844238281\n",
-            "Step: 5, loss: 70.89682006835938\n",
-            "Step: 10, loss: 47.94889831542969\n",
-            "Step: 15, loss: 34.66495132446289\n",
-            "Step: 20, loss: 26.278722763061523\n",
-            "Step: 25, loss: 20.651508331298828\n",
-            "Step: 30, loss: 16.700218200683594\n",
-            "Step: 35, loss: 13.826349258422852\n",
-            "Step: 40, loss: 11.676509857177734\n",
-            "Step: 45, loss: 10.030875205993652\n",
-            "Step: 50, loss: 8.746789932250977\n",
-            "Step: 55, loss: 7.728399276733398\n",
-            "Step: 60, loss: 6.909374713897705\n",
-            "Step: 65, loss: 6.242647647857666\n",
-            "Step: 70, loss: 5.694087505340576\n",
-            "Step: 75, loss: 5.238475799560547\n",
-            "Step: 80, loss: 4.856863975524902\n",
-            "Step: 85, loss: 4.534801483154297\n",
-            "Step: 90, loss: 4.261125087738037\n",
-            "Step: 95, loss: 4.027107238769531\n",
-            "[[ 0.73600227 -0.         -0.         -0.         -0.         -0.\n",
-            "  -0.         -0.8174586 ]\n",
-            " [-0.          0.88034064 -0.         -0.          0.         -0.\n",
-            "  -0.         -0.4709545 ]\n",
-            " [-0.7798368  -0.         -0.         -0.          0.          0.\n",
-            "  -0.         -0.7573714 ]\n",
-            " [ 0.         -0.         -1.0685847   0.         -0.         -0.\n",
-            "   0.          0.        ]\n",
-            " [ 0.          0.          0.          1.17047    -0.          0.\n",
-            "   0.          0.        ]\n",
-            " [-0.53588206 -0.7215144   0.          0.          0.         -0.\n",
-            "  -0.         -0.        ]\n",
-            " [ 0.         -0.         -0.4267249   0.          0.7517653   0.7708804\n",
-            "   0.          0.        ]\n",
-            " [ 0.         -0.          0.         -0.          0.         -0.\n",
-            "   0.          0.        ]]\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "matrix_size = 8\n",
         "\n",
@@ -893,87 +558,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 21,
+      "execution_count": null,
       "metadata": {
         "id": "Vp0KIflicNNa"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Step: 0, loss: 343.5727844238281\n",
-            "Step: 5, loss: 70.89682006835938\n",
-            "Step: 10, loss: 47.94889831542969\n",
-            "Step: 15, loss: 34.66495132446289\n",
-            "Step: 20, loss: 26.278722763061523\n",
-            "Step: 25, loss: 20.651508331298828\n",
-            "Step: 30, loss: 16.700218200683594\n",
-            "Step: 35, loss: 13.826349258422852\n",
-            "Step: 40, loss: 11.676509857177734\n",
-            "Step: 45, loss: 10.030875205993652\n",
-            "Step: 50, loss: 8.746789932250977\n",
-            "Step: 55, loss: 7.728399276733398\n",
-            "Step: 60, loss: 6.909374713897705\n",
-            "Step: 65, loss: 6.242647647857666\n",
-            "Step: 70, loss: 5.694087505340576\n",
-            "Step: 75, loss: 5.238475799560547\n",
-            "Step: 80, loss: 4.856863975524902\n",
-            "Step: 85, loss: 4.534801483154297\n",
-            "Step: 90, loss: 4.261125087738037\n",
-            "Step: 95, loss: 4.027107238769531\n",
-            "[[ 0.73600227 -0.         -0.         -0.         -0.         -0.\n",
-            "  -0.         -0.8174586 ]\n",
-            " [-0.          0.88034064 -0.         -0.          0.         -0.\n",
-            "  -0.         -0.4709545 ]\n",
-            " [-0.7798368  -0.         -0.         -0.          0.          0.\n",
-            "  -0.         -0.7573714 ]\n",
-            " [ 0.         -0.         -1.0685847   0.         -0.         -0.\n",
-            "   0.          0.        ]\n",
-            " [ 0.          0.          0.          1.17047    -0.          0.\n",
-            "   0.          0.        ]\n",
-            " [-0.53588206 -0.7215144   0.          0.          0.         -0.\n",
-            "  -0.         -0.        ]\n",
-            " [ 0.         -0.         -0.4267249   0.          0.7517653   0.7708804\n",
-            "   0.          0.        ]\n",
-            " [ 0.         -0.          0.         -0.          0.         -0.\n",
-            "   0.          0.        ]]\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────────────────────┐\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│         CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>         │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "└───────────────────────┘\n",
-              "</pre>\n"
-            ],
-            "text/plain": [
-              "┌───────────────────────┐\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│         CPU \u001b[1;36m0\u001b[0m         │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "│                       │\n",
-              "└───────────────────────┘\n"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "matrix_size = 8\n",
         "if jax.device_count() % 8 == 0:\n",

--- a/colabs/quick_start.ipynb
+++ b/colabs/quick_start.ipynb
@@ -56,7 +56,7 @@
       },
       "outputs": [],
       "source": [
-        "# !pip3 install git+https://github.com/google-research/jaxpruner\n",
+        "!pip3 install git+https://github.com/google-research/jaxpruner\n",
         "import jaxpruner\n",
         "import ml_collections"
       ]

--- a/colabs/quick_start.ipynb
+++ b/colabs/quick_start.ipynb
@@ -42,6 +42,7 @@
         "import jax\n",
         "import jax.numpy as jnp\n",
         "from jax.sharding import PartitionSpec\n",
+        "import jax.experimental.pjit\n",
         "import numpy as np\n",
         "import optax\n",
         "import pprint"
@@ -340,7 +341,7 @@
         "  optimizer = optax.sgd(0.05)\n",
         "  # Modification #1\n",
         "  optimizer = pruner.wrap_optax(optimizer)\n",
-        "  \n",
+        "\n",
         "  params = {'w': init_matrix}\n",
         "  opt_state = optimizer.init(params)\n",
         "\n",
@@ -576,8 +577,8 @@
         "\n",
         "grad_fn = jax.value_and_grad(loss_fn)\n",
         "\n",
-        "# Define the partition-specs for pjit; in most libraries for real models this \n",
-        "# is done somewhat automatically, yet this will likely require a small \n",
+        "# Define the partition-specs for pjit; in most libraries for real models this\n",
+        "# is done somewhat automatically, yet this will likely require a small\n",
         "# adjustment as shown below.\n",
         "\n",
         "params_partition = {\n",
@@ -597,8 +598,8 @@
         "\n",
         "@functools.partial(\n",
         "    jax.experimental.pjit.pjit,\n",
-        "    in_axis_resources=resources,\n",
-        "    out_axis_resources=resources + (None,),\n",
+        "    in_shardings=resources,\n",
+        "    out_shardings=resources + (None,),\n",
         "    static_argnames='optimizer'\n",
         ")\n",
         "def update_fn(params, opt_state, optimizer):\n",
@@ -631,18 +632,9 @@
         "    params = pruner.post_gradient_update(params, opt_state)\n",
         "    if i % 5 == 0:\n",
         "      print(f'Step: {i}, loss: {loss}')\n",
-        "  print(params['w'])\n",
+        "  print(params['w'])§\n",
         "  jax.debug.visualize_array_sharding(params['w'])"
       ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "FWKbfqVQD-tJ"
-      },
-      "outputs": [],
-      "source": []
     }
   ],
   "metadata": {

--- a/colabs/quick_start.ipynb
+++ b/colabs/quick_start.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "qTrunCDp6HAD"
       },
@@ -31,7 +31,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "id": "EdzHCJuop4ZB"
       },
@@ -50,13 +50,66 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "id": "s2cBBZEk1_DG"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Collecting git+https://github.com/google-research/jaxpruner\n",
+            "  Cloning https://github.com/google-research/jaxpruner to /private/var/folders/sq/g9fv1ssn3yqg_27cnkj1_c100000gr/T/pip-req-build-zhu9jesb\n",
+            "  Running command git clone --filter=blob:none --quiet https://github.com/google-research/jaxpruner /private/var/folders/sq/g9fv1ssn3yqg_27cnkj1_c100000gr/T/pip-req-build-zhu9jesb\n",
+            "  Resolved https://github.com/google-research/jaxpruner to commit f133ee50f31a03d0152b8b272edb534065152f5d\n",
+            "  Installing build dependencies ... \u001b[?25ldone\n",
+            "\u001b[?25h  Getting requirements to build wheel ... \u001b[?25ldone\n",
+            "\u001b[?25h  Preparing metadata (pyproject.toml) ... \u001b[?25ldone\n",
+            "\u001b[?25hRequirement already satisfied: chex in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.1.88)\n",
+            "Requirement already satisfied: flax in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.10.2)\n",
+            "Requirement already satisfied: jax in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.4.38)\n",
+            "Requirement already satisfied: jaxlib in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.4.38)\n",
+            "Requirement already satisfied: optax in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (0.2.4)\n",
+            "Requirement already satisfied: numpy in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (2.2.1)\n",
+            "Requirement already satisfied: ml-collections in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jaxpruner==0.1) (1.0.0)\n",
+            "Requirement already satisfied: absl-py>=0.9.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (2.1.0)\n",
+            "Requirement already satisfied: typing_extensions>=4.2.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (4.12.2)\n",
+            "Requirement already satisfied: setuptools in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (75.7.0)\n",
+            "Requirement already satisfied: toolz>=0.9.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from chex->jaxpruner==0.1) (1.0.0)\n",
+            "Requirement already satisfied: ml_dtypes>=0.4.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jax->jaxpruner==0.1) (0.5.0)\n",
+            "Requirement already satisfied: opt_einsum in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jax->jaxpruner==0.1) (3.4.0)\n",
+            "Requirement already satisfied: scipy>=1.10 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from jax->jaxpruner==0.1) (1.15.0)\n",
+            "Requirement already satisfied: msgpack in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (1.1.0)\n",
+            "Requirement already satisfied: orbax-checkpoint in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (0.11.0)\n",
+            "Requirement already satisfied: tensorstore in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (0.1.71)\n",
+            "Requirement already satisfied: rich>=11.1 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (13.9.4)\n",
+            "Requirement already satisfied: PyYAML>=5.4.1 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from flax->jaxpruner==0.1) (6.0.2)\n",
+            "Requirement already satisfied: six in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from ml-collections->jaxpruner==0.1) (1.17.0)\n",
+            "Requirement already satisfied: etils[epy] in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from optax->jaxpruner==0.1) (1.11.0)\n",
+            "Requirement already satisfied: markdown-it-py>=2.2.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from rich>=11.1->flax->jaxpruner==0.1) (3.0.0)\n",
+            "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from rich>=11.1->flax->jaxpruner==0.1) (2.19.1)\n",
+            "Requirement already satisfied: nest_asyncio in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (1.6.0)\n",
+            "Requirement already satisfied: protobuf in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (5.29.2)\n",
+            "Requirement already satisfied: humanize in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (4.11.0)\n",
+            "Requirement already satisfied: simplejson>=3.16.0 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from orbax-checkpoint->flax->jaxpruner==0.1) (3.19.3)\n",
+            "Requirement already satisfied: mdurl~=0.1 in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from markdown-it-py>=2.2.0->rich>=11.1->flax->jaxpruner==0.1) (0.1.2)\n",
+            "Requirement already satisfied: fsspec in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from etils[epy]->optax->jaxpruner==0.1) (2024.12.0)\n",
+            "Requirement already satisfied: importlib_resources in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from etils[epy]->optax->jaxpruner==0.1) (6.5.2)\n",
+            "Requirement already satisfied: zipp in /Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages (from etils[epy]->optax->jaxpruner==0.1) (3.21.0)\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/Users/betheridge/personal/oss/fixjaxpruner/.venv/lib/python3.12/site-packages/ml_collections/config_dict/config_dict.py:163: SyntaxWarning: invalid escape sequence '\\['\n",
+            "  index_match = re.match(\"(.*)\\[([0-9]+)\\]\", key)\n"
+          ]
+        }
+      ],
       "source": [
-        "!pip3 install git+https://github.com/google-research/jaxpruner\n",
+        "# !pip3 install git+https://github.com/google-research/jaxpruner\n",
         "import jaxpruner\n",
         "import ml_collections"
       ]
@@ -75,11 +128,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "id": "D-3sagbVuOCW"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[0.28248537 0.0030005  0.5755601  0.80048716 0.24104941]\n",
+            " [0.4520849  0.30063164 0.11872995 0.9262264  0.02943528]\n",
+            " [0.77339077 0.9098681  0.30932128 0.9311595  0.7131189 ]\n",
+            " [0.76767194 0.60364604 0.54187894 0.54719424 0.68919384]\n",
+            " [0.6382148  0.9619373  0.9574717  0.21418309 0.21543407]]\n"
+          ]
+        }
+      ],
       "source": [
         "matrix_size = 5\n",
         "learning_rate = 0.01\n",
@@ -89,11 +154,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 5,
       "metadata": {
         "id": "G51lY-u3xxa6"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[0.        0.        0.        0.        0.       ]\n",
+            " [0.        0.        0.        0.9262264 0.       ]\n",
+            " [0.        0.9098681 0.        0.9311595 0.       ]\n",
+            " [0.        0.        0.        0.        0.       ]\n",
+            " [0.        0.9619373 0.9574717 0.        0.       ]]\n",
+            "uint8\n",
+            "[[0 0 0 0 0]\n",
+            " [0 0 0 1 0]\n",
+            " [0 1 0 1 0]\n",
+            " [0 0 0 0 0]\n",
+            " [0 1 1 0 0]]\n"
+          ]
+        }
+      ],
       "source": [
         "sparsity_distribution = functools.partial(\n",
         "    jaxpruner.sparsity_distributions.uniform, sparsity=0.8)\n",
@@ -116,11 +199,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "metadata": {
         "id": "JCwUUA2SCkTy"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[0.         0.         0.         0.80048716 0.        ]\n",
+            " [0.         0.         0.         0.9262264  0.        ]\n",
+            " [0.         0.         0.         0.9311595  0.        ]\n",
+            " [0.76767194 0.         0.         0.         0.        ]\n",
+            " [0.         0.9619373  0.         0.         0.        ]]\n",
+            "uint8\n",
+            "[[0 0 0 1 0]\n",
+            " [0 0 0 1 0]\n",
+            " [0 0 0 1 0]\n",
+            " [1 0 0 0 0]\n",
+            " [0 1 0 0 0]]\n"
+          ]
+        }
+      ],
       "source": [
         "pruner = jaxpruner.MagnitudePruning(sparsity_distribution_fn=sparsity_distribution,\n",
         "                                    sparsity_type=jaxpruner.sparsity_types.NByM(1, 5))\n",
@@ -142,11 +243,28 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "metadata": {
         "id": "w7swztVv1pwN"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "{'inv': Array([[0.        , 0.9969995 , 0.        , 0.        , 0.        ],\n",
+            "       [0.        , 0.        , 0.        , 0.        , 0.9705647 ],\n",
+            "       [0.        , 0.        , 0.6906787 , 0.        , 0.        ],\n",
+            "       [0.        , 0.        , 0.45812106, 0.        , 0.        ],\n",
+            "       [0.        , 0.        , 0.        , 0.7858169 , 0.        ]],      dtype=float32),\n",
+            " 'pos': Array([[0.        , 0.        , 0.        , 0.80048716, 0.        ],\n",
+            "       [0.        , 0.        , 0.        , 0.9262264 , 0.        ],\n",
+            "       [0.        , 0.        , 0.        , 0.9311595 , 0.        ],\n",
+            "       [0.76767194, 0.        , 0.        , 0.        , 0.        ],\n",
+            "       [0.        , 0.9619373 , 0.        , 0.        , 0.        ]],      dtype=float32)}\n"
+          ]
+        }
+      ],
       "source": [
         "# params = [matrix, 1 - matrix]\n",
         "params = {'pos': matrix, 'inv': 1 - matrix}\n",
@@ -165,11 +283,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 8,
       "metadata": {
         "id": "XN2954cfFChC"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "{'_nparams': Array(50., dtype=float32),\n",
+            " '_nparams_nnz': Array(20., dtype=float32),\n",
+            " '_total_sparsity': Array(0.6, dtype=float32),\n",
+            " 'inv': Array(0.8, dtype=float32),\n",
+            " 'pos': Array(0.39999998, dtype=float32)}\n"
+          ]
+        }
+      ],
       "source": [
         "def custom_distribution(params, sparsity=0.8):\n",
         "  return {key: 0.4 if 'pos' in key else sparsity for key in params}\n",
@@ -190,11 +320,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 9,
       "metadata": {
         "id": "nOaXL58kpZfv"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "{'inv': Array([[0, 1, 0, 0, 0],\n",
+            "       [0, 0, 1, 0, 1],\n",
+            "       [0, 0, 0, 0, 0],\n",
+            "       [0, 0, 0, 0, 0],\n",
+            "       [0, 0, 0, 1, 1]], dtype=uint8),\n",
+            " 'pos': None}\n"
+          ]
+        }
+      ],
       "source": [
         "def custom_distribution2(params, sparsity=0.8):\n",
         "  return {key: None if 'pos' in key else sparsity for key in params}\n",
@@ -215,11 +358,29 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 10,
       "metadata": {
         "id": "VZUIsC1NH5JV"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "no_prune <class 'jaxpruner.base_updater.NoPruning'>\n",
+            "magnitude <class 'jaxpruner.algorithms.pruners.MagnitudePruning'>\n",
+            "random <class 'jaxpruner.algorithms.pruners.RandomPruning'>\n",
+            "saliency <class 'jaxpruner.algorithms.pruners.SaliencyPruning'>\n",
+            "magnitude_ste <class 'jaxpruner.algorithms.ste.SteMagnitudePruning'>\n",
+            "random_ste <class 'jaxpruner.algorithms.ste.SteRandomPruning'>\n",
+            "global_magnitude <class 'jaxpruner.algorithms.global_pruners.GlobalMagnitudePruning'>\n",
+            "global_saliency <class 'jaxpruner.algorithms.global_pruners.GlobalSaliencyPruning'>\n",
+            "static_sparse <class 'jaxpruner.algorithms.sparse_trainers.StaticRandomSparse'>\n",
+            "rigl <class 'jaxpruner.algorithms.sparse_trainers.RigL'>\n",
+            "set <class 'jaxpruner.algorithms.sparse_trainers.SET'>\n"
+          ]
+        }
+      ],
       "source": [
         "for k in jaxpruner.ALGORITHM_REGISTRY:\n",
         "  print(k, jaxpruner.ALGORITHM_REGISTRY[k])"
@@ -236,11 +397,23 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 11,
       "metadata": {
         "id": "n_1waBgM2Epe"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[0.         0.         0.5755601  0.         0.        ]\n",
+            " [0.4520849  0.         0.         0.         0.        ]\n",
+            " [0.         0.         0.         0.         0.        ]\n",
+            " [0.         0.60364604 0.54187894 0.54719424 0.        ]\n",
+            " [0.         0.         0.         0.         0.        ]]\n"
+          ]
+        }
+      ],
       "source": [
         "# Gradient based pruning\n",
         "pruner = jaxpruner.SaliencyPruning(sparsity_distribution_fn=sparsity_distribution)\n",
@@ -264,7 +437,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 12,
       "metadata": {
         "id": "ZPVLns38l-sS"
       },
@@ -309,11 +482,37 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 13,
       "metadata": {
         "id": "imi-PawzUS_6"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Step: 0, loss: 50.740779876708984\n",
+            "Step: 4, loss: 1.0821640491485596\n",
+            "Step: 8, loss: 0.5029404163360596\n",
+            "Step: 12, loss: 0.09175926446914673\n",
+            "Step: 16, loss: 0.0036935126408934593\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Array([[-0.5452558 , -0.68374544,  0.39526057,  0.27897137, -0.01504929],\n",
+              "       [ 0.18433541, -0.26916775, -0.45707935,  0.31126106, -0.76552254],\n",
+              "       [-0.6820641 ,  0.08165327, -0.69178694, -0.14950337,  0.15661548],\n",
+              "       [ 0.33259526, -0.6524972 , -0.23232982, -0.6030979 ,  0.20593995],\n",
+              "       [-0.2942041 ,  0.16224197,  0.3196011 , -0.66244096, -0.5882758 ]],      dtype=float32)"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "params = jax.random.uniform(jax.random.PRNGKey(8),\n",
         "                            shape=(matrix_size, matrix_size))\n",
@@ -331,7 +530,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "metadata": {
         "id": "plZ5bqDhT4cR"
       },
@@ -369,11 +568,42 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "metadata": {
         "id": "TqaMojfRNGHd"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Step: 0, loss: 50.740779876708984\n",
+            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 4, loss: 1.0821640491485596\n",
+            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 8, loss: 0.5029404163360596\n",
+            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 12, loss: 1.8950453996658325\n",
+            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 16, loss: 1.3515889644622803\n",
+            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Array([[-0.        , -0.99310285,  0.        ,  0.        , -0.        ],\n",
+              "       [ 0.        , -0.        , -0.        ,  0.        , -0.9267426 ],\n",
+              "       [-0.        ,  0.        , -0.9929704 , -0.        ,  0.        ],\n",
+              "       [ 0.        , -0.        , -0.        , -0.        ,  0.        ],\n",
+              "       [-0.        ,  0.        ,  0.        , -0.9202637 , -0.2308394 ]],      dtype=float32)"
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "pruner = jaxpruner.MagnitudePruning(\n",
         "    sparsity_distribution_fn=sparsity_distribution,\n",
@@ -395,11 +625,42 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 16,
       "metadata": {
         "id": "Tg9MAEYsO8YU"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Step: 0, loss: 50.740779876708984\n",
+            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 4, loss: 1.0821640491485596\n",
+            "{'_total_sparsity': Array(0.48000002, dtype=float32), '_nparams_nnz': Array(13., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 8, loss: 1.2138574123382568\n",
+            "{'_total_sparsity': Array(0.76, dtype=float32), '_nparams_nnz': Array(6., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 12, loss: 1.3473515510559082\n",
+            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 16, loss: 1.0177024602890015\n",
+            "{'_total_sparsity': Array(0.8, dtype=float32), '_nparams_nnz': Array(5., dtype=float32), '_nparams': Array(25., dtype=float32)}\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Array([[-0.        , -0.9976892 ,  0.        ,  0.        , -0.        ],\n",
+              "       [ 0.        , -0.        , -0.        ,  0.        , -0.9915333 ],\n",
+              "       [-0.        , -0.        , -0.99801445, -0.        ,  0.        ],\n",
+              "       [ 0.        , -0.        , -0.        , -0.67936283,  0.        ],\n",
+              "       [-0.        ,  0.        ,  0.        , -0.7284256 , -0.        ]],      dtype=float32)"
+            ]
+          },
+          "execution_count": 16,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "pruner = jaxpruner.MagnitudePruning(\n",
         "    sparsity_distribution_fn=sparsity_distribution,\n",
@@ -431,7 +692,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 17,
       "metadata": {
         "id": "TKY_GSumHYRI"
       },
@@ -448,11 +709,42 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "metadata": {
         "id": "Uqqg0sYIHWNm"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Step: 0, loss: 50.740779876708984\n",
+            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 4, loss: 1.0821640491485596\n",
+            "{'_total_sparsity': Array(0., dtype=float32), '_nparams_nnz': Array(25., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 8, loss: 0.7265740036964417\n",
+            "{'_total_sparsity': Array(0.48000002, dtype=float32), '_nparams_nnz': Array(13., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 12, loss: 1.3116353750228882\n",
+            "{'_total_sparsity': Array(0.6, dtype=float32), '_nparams_nnz': Array(10., dtype=float32), '_nparams': Array(25., dtype=float32)}\n",
+            "Step: 16, loss: 1.129997730255127\n",
+            "{'_total_sparsity': Array(0.6, dtype=float32), '_nparams_nnz': Array(10., dtype=float32), '_nparams': Array(25., dtype=float32)}\n"
+          ]
+        },
+        {
+          "data": {
+            "text/plain": [
+              "Array([[-0.5102305 , -0.6804417 ,  0.        ,  0.        , -0.        ],\n",
+              "       [ 0.        , -0.        , -0.        ,  0.5152243 , -0.8074678 ],\n",
+              "       [-0.44380936,  0.        , -0.8579842 , -0.        ,  0.        ],\n",
+              "       [ 0.        , -0.55724764, -0.        , -0.38684854,  0.        ],\n",
+              "       [-0.        ,  0.        ,  0.        , -0.72127473, -0.58689326]],      dtype=float32)"
+            ]
+          },
+          "execution_count": 18,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# Create a dense layer and sparsify.\n",
         "pruner = jaxpruner.create_updater_from_config(sparsity_config)\n",
@@ -489,11 +781,54 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 19,
       "metadata": {
         "id": "T8EchfPLEei-"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Step: 0, loss: 343.5727844238281\n",
+            "Step: 5, loss: 70.89682006835938\n",
+            "Step: 10, loss: 47.94889831542969\n",
+            "Step: 15, loss: 34.66495132446289\n",
+            "Step: 20, loss: 26.278722763061523\n",
+            "Step: 25, loss: 20.651508331298828\n",
+            "Step: 30, loss: 16.700218200683594\n",
+            "Step: 35, loss: 13.826349258422852\n",
+            "Step: 40, loss: 11.676509857177734\n",
+            "Step: 45, loss: 10.030875205993652\n",
+            "Step: 50, loss: 8.746789932250977\n",
+            "Step: 55, loss: 7.728399276733398\n",
+            "Step: 60, loss: 6.909374713897705\n",
+            "Step: 65, loss: 6.242647647857666\n",
+            "Step: 70, loss: 5.694087505340576\n",
+            "Step: 75, loss: 5.238475799560547\n",
+            "Step: 80, loss: 4.856863975524902\n",
+            "Step: 85, loss: 4.534801483154297\n",
+            "Step: 90, loss: 4.261125087738037\n",
+            "Step: 95, loss: 4.027107238769531\n",
+            "[[ 0.73600227 -0.         -0.         -0.         -0.         -0.\n",
+            "  -0.         -0.8174586 ]\n",
+            " [-0.          0.88034064 -0.         -0.          0.         -0.\n",
+            "  -0.         -0.4709545 ]\n",
+            " [-0.7798368  -0.         -0.         -0.          0.          0.\n",
+            "  -0.         -0.7573714 ]\n",
+            " [ 0.         -0.         -1.0685847   0.         -0.         -0.\n",
+            "   0.          0.        ]\n",
+            " [ 0.          0.          0.          1.17047    -0.          0.\n",
+            "   0.          0.        ]\n",
+            " [-0.53588206 -0.7215144   0.          0.          0.         -0.\n",
+            "  -0.         -0.        ]\n",
+            " [ 0.         -0.         -0.4267249   0.          0.7517653   0.7708804\n",
+            "   0.          0.        ]\n",
+            " [ 0.         -0.          0.         -0.          0.         -0.\n",
+            "   0.          0.        ]]\n"
+          ]
+        }
+      ],
       "source": [
         "matrix_size = 8\n",
         "\n",
@@ -558,11 +893,87 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 21,
       "metadata": {
         "id": "Vp0KIflicNNa"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Step: 0, loss: 343.5727844238281\n",
+            "Step: 5, loss: 70.89682006835938\n",
+            "Step: 10, loss: 47.94889831542969\n",
+            "Step: 15, loss: 34.66495132446289\n",
+            "Step: 20, loss: 26.278722763061523\n",
+            "Step: 25, loss: 20.651508331298828\n",
+            "Step: 30, loss: 16.700218200683594\n",
+            "Step: 35, loss: 13.826349258422852\n",
+            "Step: 40, loss: 11.676509857177734\n",
+            "Step: 45, loss: 10.030875205993652\n",
+            "Step: 50, loss: 8.746789932250977\n",
+            "Step: 55, loss: 7.728399276733398\n",
+            "Step: 60, loss: 6.909374713897705\n",
+            "Step: 65, loss: 6.242647647857666\n",
+            "Step: 70, loss: 5.694087505340576\n",
+            "Step: 75, loss: 5.238475799560547\n",
+            "Step: 80, loss: 4.856863975524902\n",
+            "Step: 85, loss: 4.534801483154297\n",
+            "Step: 90, loss: 4.261125087738037\n",
+            "Step: 95, loss: 4.027107238769531\n",
+            "[[ 0.73600227 -0.         -0.         -0.         -0.         -0.\n",
+            "  -0.         -0.8174586 ]\n",
+            " [-0.          0.88034064 -0.         -0.          0.         -0.\n",
+            "  -0.         -0.4709545 ]\n",
+            " [-0.7798368  -0.         -0.         -0.          0.          0.\n",
+            "  -0.         -0.7573714 ]\n",
+            " [ 0.         -0.         -1.0685847   0.         -0.         -0.\n",
+            "   0.          0.        ]\n",
+            " [ 0.          0.          0.          1.17047    -0.          0.\n",
+            "   0.          0.        ]\n",
+            " [-0.53588206 -0.7215144   0.          0.          0.         -0.\n",
+            "  -0.         -0.        ]\n",
+            " [ 0.         -0.         -0.4267249   0.          0.7517653   0.7708804\n",
+            "   0.          0.        ]\n",
+            " [ 0.         -0.          0.         -0.          0.         -0.\n",
+            "   0.          0.        ]]\n"
+          ]
+        },
+        {
+          "data": {
+            "text/html": [
+              "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┌───────────────────────┐\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│         CPU <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>         │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "└───────────────────────┘\n",
+              "</pre>\n"
+            ],
+            "text/plain": [
+              "┌───────────────────────┐\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│         CPU \u001b[1;36m0\u001b[0m         │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "│                       │\n",
+              "└───────────────────────┘\n"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "matrix_size = 8\n",
         "if jax.device_count() % 8 == 0:\n",
@@ -632,7 +1043,7 @@
         "    params = pruner.post_gradient_update(params, opt_state)\n",
         "    if i % 5 == 0:\n",
         "      print(f'Step: {i}, loss: {loss}')\n",
-        "  print(params['w'])§\n",
+        "  print(params['w'])\n",
         "  jax.debug.visualize_array_sharding(params['w'])"
       ]
     }
@@ -650,11 +1061,21 @@
       "toc_visible": true
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": ".venv",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.5"
     },
     "orig_nbformat": 2
   },


### PR DESCRIPTION
The final cell of `colabs/quick_start.ipynb` was failing to run due to some changes in how `pjit` is implemented in more recent jax releases.

In release [0.4.14](https://github.com/jax-ml/jax/releases/tag/jax-v0.4.14) (July 27, 2023) the following is listed in the [changelog](https://raw.githubusercontent.com/jax-ml/jax/refs/heads/main/CHANGELOG.md):
```
* Deletions
  * `in_axis_resources` and `out_axis_resources` have been deleted from pjit since
    it has been more than 3 months since their deprecation. Please use
    `in_shardings` and `out_shardings` as the replacement.
    This is a safe and trivial name replacement. It does not change any of the
    current pjit semantics and doesn't break any code.
    You can still pass in `PartitionSpecs` to in_shardings and out_shardings.
```

As such, the cell has been modified to use `in_shardings` and `out_shardings` as kwargs, rather than `in_axis_resources` and `out_axis_resources`. 

An explicit `import jax.experimental.pjit` has also been added in the import cell as otherwise the module was not being recognised.

This PR resolves issue #10.
